### PR TITLE
Adding test and fix for ^uint64(0) -> float 

### DIFF
--- a/safecast.go
+++ b/safecast.go
@@ -27,17 +27,17 @@ type Number interface {
 
 var ErrOutOfRange = errors.New("out of range")
 
-func Negative[T Number](t T) bool {
-	return t < 0
-}
-
-func SameSign[T1, T2 Number](a T1, b T2) bool {
-	return Negative(a) == Negative(b)
-}
+const all64bitsOne = ^uint64(0) // same as uint64(math.MaxUint64)
 
 func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err error) {
+	origPositive := orig > 0
+	// all bits set on uint64 is the only special case not detected by roundtrip (afaik).
+	if origPositive && (uint64(orig) == all64bitsOne) {
+		err = ErrOutOfRange
+		return
+	}
 	converted = NumOut(orig)
-	if !SameSign(orig, converted) {
+	if origPositive != (converted > 0) {
 		err = ErrOutOfRange
 		return
 	}

--- a/safecast.go
+++ b/safecast.go
@@ -29,6 +29,13 @@ var ErrOutOfRange = errors.New("out of range")
 
 const all64bitsOne = ^uint64(0) // same as uint64(math.MaxUint64)
 
+// Convert converts a number from one type to another,
+// returning an error if the conversion would result in a loss of precision,
+// range or sign (overflow). In other words if the converted number is not
+// equal to the original number.
+// Do not use for identity (same type in and out) but in particular this
+// will error for Convert[uint64](uint64(math.MaxUint64)) because it needs to
+// when converting to any float.
 func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err error) {
 	origPositive := orig > 0
 	// all bits set on uint64 is the only special case not detected by roundtrip (afaik).
@@ -47,6 +54,7 @@ func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err err
 	return
 }
 
+// Same as Convert but panics if there is an error.
 func MustConvert[NumOut Number, NumIn Number](orig NumIn) NumOut {
 	converted, err := Convert[NumOut, NumIn](orig)
 	if err != nil {
@@ -55,14 +63,19 @@ func MustConvert[NumOut Number, NumIn Number](orig NumIn) NumOut {
 	return converted
 }
 
+// Converts a float to an integer by truncating the fractional part.
+// Returns an error if the conversion would result in a loss of precision.
 func Truncate[NumOut Number, NumIn Float](orig NumIn) (converted NumOut, err error) {
 	return Convert[NumOut](math.Trunc(float64(orig)))
 }
 
+// Converts a float to an integer by rounding to the nearest integer.
+// Returns an error if the conversion would result in a loss of precision.
 func Round[NumOut Number, NumIn Float](orig NumIn) (converted NumOut, err error) {
 	return Convert[NumOut](math.Round(float64(orig)))
 }
 
+// Same as Truncate but panics if there is an error.
 func MustTruncate[NumOut Number, NumIn Float](orig NumIn) NumOut {
 	converted, err := Truncate[NumOut, NumIn](orig)
 	if err != nil {
@@ -71,6 +84,7 @@ func MustTruncate[NumOut Number, NumIn Float](orig NumIn) NumOut {
 	return converted
 }
 
+// Same as Round but panics if there is an error.
 func MustRound[NumOut Number, NumIn Float](orig NumIn) NumOut {
 	converted, err := Round[NumOut, NumIn](orig)
 	if err != nil {

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -12,11 +12,16 @@ import (
 
 const all64bitsOne = ^uint64(0)
 
+// Interesting part is the "true" for the first line, which is why we have to change the
+// code in Convert to handle that 1 special case.
+// safecast_test.go:22: bits 64: 1111111111111111111111111111111111111111111111111111111111111111
+// : 18446744073709551615 -> float64 18446744073709551616 true.
 func FindNumIntBits[T safecast.Float](t *testing.T) int {
 	var v T
 	for i := 0; i < 64; i++ {
 		bits := (all64bitsOne >> i)
 		v = T(bits)
+		t.Logf("bits %02d: %b : %d -> %T %.0f %t", 64-i, bits, bits, v, v, uint64(v) == bits)
 		if v != v-1 {
 			return 64 - i
 		}
@@ -26,8 +31,8 @@ func FindNumIntBits[T safecast.Float](t *testing.T) int {
 
 func TestFloatBounds(t *testing.T) {
 	float32bits := FindNumIntBits[float32](t)
-	float64bits := FindNumIntBits[float64](t)
 	t.Logf("float32: %d bits", float32bits)
+	float64bits := FindNumIntBits[float64](t)
 	t.Logf("float64: %d bits", float64bits)
 	f32, err := safecast.Convert[float32](all64bitsOne)
 	if err == nil {

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -9,6 +9,35 @@ import (
 
 // TODO: steal the tests from https://github.com/ccoVeille/go-safecast
 
+const all64bitsOne = ^uint64(0)
+
+func FindNumIntBits[T safecast.Float](t *testing.T) int {
+	var v T
+	for i := 0; i < 64; i++ {
+		bits := (all64bitsOne >> i)
+		v = T(bits)
+		if v != v-1 {
+			return 64 - i
+		}
+	}
+	panic("bug... didn't fine num bits")
+}
+
+func TestFloatBounds(t *testing.T) {
+	float32bits := FindNumIntBits[float32](t)
+	float64bits := FindNumIntBits[float64](t)
+	t.Logf("float32: %d bits", float32bits)
+	t.Logf("float64: %d bits", float64bits)
+	f32, err := safecast.Convert[float32](all64bitsOne)
+	if err == nil {
+		t.Errorf("expected error, got %d -> %.0f", all64bitsOne, f32)
+	}
+	f64, err := safecast.Convert[float64](all64bitsOne)
+	if err == nil {
+		t.Errorf("expected error, got %d -> %.0f", all64bitsOne, f64)
+	}
+}
+
 func TestConvert(t *testing.T) {
 	var inp uint32 = 42
 	out, err := safecast.Convert[int8](inp)

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -53,6 +53,35 @@ func TestFloat64Bounds(t *testing.T) {
 	}
 }
 
+func TestNonIntegerFloat(t *testing.T) {
+	_, err := safecast.Convert[int](math.Pi)
+	if err == nil {
+		t.Errorf("expected error")
+	}
+	var truncPi float64 = math.Trunc(math.Pi)
+	i, err := safecast.Convert[int](truncPi)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 3 {
+		t.Errorf("unexpected value: %v", i)
+	}
+	i, err = safecast.Truncate[int](math.Pi)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 3 {
+		t.Errorf("unexpected value: %v", i)
+	}
+	i, err = safecast.Round[int](math.Phi)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if i != 2 {
+		t.Errorf("unexpected value: %v", i)
+	}
+}
+
 // MaxUint64 special case and also MaxInt64+1.
 func TestMaxInt64(t *testing.T) {
 	f32, err := safecast.Convert[float32](all64bitsOne)

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -58,7 +58,7 @@ func TestNonIntegerFloat(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error")
 	}
-	var truncPi float64 = math.Trunc(math.Pi)
+	truncPi := math.Trunc(math.Pi) // math.Trunc returns a float64
 	i, err := safecast.Convert[int](truncPi)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -2,6 +2,7 @@ package safecast_test
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"fortio.org/safecast"
@@ -36,6 +37,15 @@ func TestFloatBounds(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error, got %d -> %.0f", all64bitsOne, f64)
 	}
+	minInt64p1 := int64(math.MinInt64) + 1 // not a power of 2
+	t.Logf("minInt64p1 %b %d", minInt64p1, minInt64p1)
+	_, err = safecast.Convert[float64](minInt64p1)
+	f64 = float64(minInt64p1)
+	int2 := int64(f64)
+	t.Logf("minInt64p1 -> %.0f %d", f64, int2)
+	if err == nil {
+		t.Errorf("expected error, got %d -> %.0f", minInt64p1, f64)
+	}
 }
 
 func TestConvert(t *testing.T) {
@@ -54,7 +64,7 @@ func TestConvert(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error")
 	}
-	inp2 := int32(-42)
+	inp2 := int32(-1)
 	_, err = safecast.Convert[uint8](inp2)
 	t.Logf("Got err: %v", err)
 	if err == nil {
@@ -65,7 +75,7 @@ func TestConvert(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if out != -42 {
+	if out != -1 {
 		t.Errorf("unexpected value: %v", out)
 	}
 	inp2 = -129

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -29,11 +29,32 @@ func FindNumIntBits[T safecast.Float](t *testing.T) int {
 	panic("bug... didn't fine num bits")
 }
 
-func TestFloatBounds(t *testing.T) {
+func TestFloat32Bounds(t *testing.T) {
 	float32bits := FindNumIntBits[float32](t)
 	t.Logf("float32: %d bits", float32bits)
+	float32int := uint64(1<<(float32bits) - 1) // 24 bits
+	for i := 0; i <= 64-float32bits; i++ {
+		t.Logf("float32int %b %d", float32int, float32int)
+		f := safecast.MustConvert[float32](float32int)
+		t.Logf("float32int -> %.0f", f)
+		float32int <<= 1
+	}
+}
+
+func TestFloat64Bounds(t *testing.T) {
 	float64bits := FindNumIntBits[float64](t)
 	t.Logf("float64: %d bits", float64bits)
+	float64int := uint64(1<<(float64bits) - 1) // 53 bits
+	for i := 0; i <= 64-float64bits; i++ {
+		t.Logf("float64int %b %d", float64int, float64int)
+		f := safecast.MustConvert[float64](float64int)
+		t.Logf("float64int -> %.0f", f)
+		float64int <<= 1
+	}
+}
+
+// MaxUint64 special case and also MaxInt64+1.
+func TestMaxInt64(t *testing.T) {
 	f32, err := safecast.Convert[float32](all64bitsOne)
 	if err == nil {
 		t.Errorf("expected error, got %d -> %.0f", all64bitsOne, f32)


### PR DESCRIPTION
Also reduce API surface. removed Negative() and SameSign()

```
=== RUN   TestFloatBounds
    safecast_test.go:24: bits 64: 1111111111111111111111111111111111111111111111111111111111111111 : 18446744073709551615 -> float32 18446744073709551616 true
    safecast_test.go:24: bits 63: 111111111111111111111111111111111111111111111111111111111111111 : 9223372036854775807 -> float32 9223372036854775808 false
    safecast_test.go:24: bits 62: 11111111111111111111111111111111111111111111111111111111111111 : 4611686018427387903 -> float32 4611686018427387904 false
    safecast_test.go:24: bits 61: 1111111111111111111111111111111111111111111111111111111111111 : 2305843009213693951 -> float32 2305843009213693952 false
    safecast_test.go:24: bits 60: 111111111111111111111111111111111111111111111111111111111111 : 1152921504606846975 -> float32 1152921504606846976 false
    safecast_test.go:24: bits 59: 11111111111111111111111111111111111111111111111111111111111 : 576460752303423487 -> float32 576460752303423488 false
    safecast_test.go:24: bits 58: 1111111111111111111111111111111111111111111111111111111111 : 288230376151711743 -> float32 288230376151711744 false
    safecast_test.go:24: bits 57: 111111111111111111111111111111111111111111111111111111111 : 144115188075855871 -> float32 144115188075855872 false
    safecast_test.go:24: bits 56: 11111111111111111111111111111111111111111111111111111111 : 72057594037927935 -> float32 72057594037927936 false
    safecast_test.go:24: bits 55: 1111111111111111111111111111111111111111111111111111111 : 36028797018963967 -> float32 36028797018963968 false
    safecast_test.go:24: bits 54: 111111111111111111111111111111111111111111111111111111 : 18014398509481983 -> float32 18014398509481984 false
    safecast_test.go:24: bits 53: 11111111111111111111111111111111111111111111111111111 : 9007199254740991 -> float32 9007199254740992 false
    safecast_test.go:24: bits 52: 1111111111111111111111111111111111111111111111111111 : 4503599627370495 -> float32 4503599627370496 false
    safecast_test.go:24: bits 51: 111111111111111111111111111111111111111111111111111 : 2251799813685247 -> float32 2251799813685248 false
    safecast_test.go:24: bits 50: 11111111111111111111111111111111111111111111111111 : 1125899906842623 -> float32 1125899906842624 false
    safecast_test.go:24: bits 49: 1111111111111111111111111111111111111111111111111 : 562949953421311 -> float32 562949953421312 false
    safecast_test.go:24: bits 48: 111111111111111111111111111111111111111111111111 : 281474976710655 -> float32 281474976710656 false
    safecast_test.go:24: bits 47: 11111111111111111111111111111111111111111111111 : 140737488355327 -> float32 140737488355328 false
    safecast_test.go:24: bits 46: 1111111111111111111111111111111111111111111111 : 70368744177663 -> float32 70368744177664 false
    safecast_test.go:24: bits 45: 111111111111111111111111111111111111111111111 : 35184372088831 -> float32 35184372088832 false
    safecast_test.go:24: bits 44: 11111111111111111111111111111111111111111111 : 17592186044415 -> float32 17592186044416 false
    safecast_test.go:24: bits 43: 1111111111111111111111111111111111111111111 : 8796093022207 -> float32 8796093022208 false
    safecast_test.go:24: bits 42: 111111111111111111111111111111111111111111 : 4398046511103 -> float32 4398046511104 false
    safecast_test.go:24: bits 41: 11111111111111111111111111111111111111111 : 2199023255551 -> float32 2199023255552 false
    safecast_test.go:24: bits 40: 1111111111111111111111111111111111111111 : 1099511627775 -> float32 1099511627776 false
    safecast_test.go:24: bits 39: 111111111111111111111111111111111111111 : 549755813887 -> float32 549755813888 false
    safecast_test.go:24: bits 38: 11111111111111111111111111111111111111 : 274877906943 -> float32 274877906944 false
    safecast_test.go:24: bits 37: 1111111111111111111111111111111111111 : 137438953471 -> float32 137438953472 false
    safecast_test.go:24: bits 36: 111111111111111111111111111111111111 : 68719476735 -> float32 68719476736 false
    safecast_test.go:24: bits 35: 11111111111111111111111111111111111 : 34359738367 -> float32 34359738368 false
    safecast_test.go:24: bits 34: 1111111111111111111111111111111111 : 17179869183 -> float32 17179869184 false
    safecast_test.go:24: bits 33: 111111111111111111111111111111111 : 8589934591 -> float32 8589934592 false
    safecast_test.go:24: bits 32: 11111111111111111111111111111111 : 4294967295 -> float32 4294967296 false
    safecast_test.go:24: bits 31: 1111111111111111111111111111111 : 2147483647 -> float32 2147483648 false
    safecast_test.go:24: bits 30: 111111111111111111111111111111 : 1073741823 -> float32 1073741824 false
    safecast_test.go:24: bits 29: 11111111111111111111111111111 : 536870911 -> float32 536870912 false
    safecast_test.go:24: bits 28: 1111111111111111111111111111 : 268435455 -> float32 268435456 false
    safecast_test.go:24: bits 27: 111111111111111111111111111 : 134217727 -> float32 134217728 false
    safecast_test.go:24: bits 26: 11111111111111111111111111 : 67108863 -> float32 67108864 false
    safecast_test.go:24: bits 25: 1111111111111111111111111 : 33554431 -> float32 33554432 false
    safecast_test.go:24: bits 24: 111111111111111111111111 : 16777215 -> float32 16777215 true
    safecast_test.go:34: float32: 24 bits
    safecast_test.go:24: bits 64: 1111111111111111111111111111111111111111111111111111111111111111 : 18446744073709551615 -> float64 18446744073709551616 true
    safecast_test.go:24: bits 63: 111111111111111111111111111111111111111111111111111111111111111 : 9223372036854775807 -> float64 9223372036854775808 false
    safecast_test.go:24: bits 62: 11111111111111111111111111111111111111111111111111111111111111 : 4611686018427387903 -> float64 4611686018427387904 false
    safecast_test.go:24: bits 61: 1111111111111111111111111111111111111111111111111111111111111 : 2305843009213693951 -> float64 2305843009213693952 false
    safecast_test.go:24: bits 60: 111111111111111111111111111111111111111111111111111111111111 : 1152921504606846975 -> float64 1152921504606846976 false
    safecast_test.go:24: bits 59: 11111111111111111111111111111111111111111111111111111111111 : 576460752303423487 -> float64 576460752303423488 false
    safecast_test.go:24: bits 58: 1111111111111111111111111111111111111111111111111111111111 : 288230376151711743 -> float64 288230376151711744 false
    safecast_test.go:24: bits 57: 111111111111111111111111111111111111111111111111111111111 : 144115188075855871 -> float64 144115188075855872 false
    safecast_test.go:24: bits 56: 11111111111111111111111111111111111111111111111111111111 : 72057594037927935 -> float64 72057594037927936 false
    safecast_test.go:24: bits 55: 1111111111111111111111111111111111111111111111111111111 : 36028797018963967 -> float64 36028797018963968 false
    safecast_test.go:24: bits 54: 111111111111111111111111111111111111111111111111111111 : 18014398509481983 -> float64 18014398509481984 false
    safecast_test.go:24: bits 53: 11111111111111111111111111111111111111111111111111111 : 9007199254740991 -> float64 9007199254740991 true
    safecast_test.go:36: float64: 53 bits
    safecast_test.go:46: minInt64p1 -111111111111111111111111111111111111111111111111111111111111111 -9223372036854775807
    safecast_test.go:50: minInt64p1 -> -9223372036854775808 -9223372036854775808
--- PASS: TestFloatBounds (0.00s)
```