### PR TITLE
test for bit patterns, removed special case

### DIFF
--- a/safecast.go
+++ b/safecast.go
@@ -41,7 +41,7 @@ func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err err
 	if NumIn(converted) != orig {
 		// checking for NaNs is completely optimized out for integer types.
 		// we declare NaN mantissa bits truncation during float64 -> float32 conversion as safe
-		bothNaN := (orig != orig) && (converted != converted)
+		bothNaN := (orig != orig) && (converted != converted) //nolint:gocritic // standard NaNs trick
 		if !bothNaN {
 			err = ErrOutOfRange
 		}

--- a/safecast.go
+++ b/safecast.go
@@ -27,29 +27,24 @@ type Number interface {
 
 var ErrOutOfRange = errors.New("out of range")
 
-const all64bitsOne = ^uint64(0) // same as uint64(math.MaxUint64)
-
 // Convert converts a number from one type to another,
 // returning an error if the conversion would result in a loss of precision,
 // range or sign (overflow). In other words if the converted number is not
 // equal to the original number.
-// Do not use for identity (same type in and out) but in particular this
-// will error for Convert[uint64](uint64(math.MaxUint64)) because it needs to
-// when converting to any float.
 func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err error) {
 	origPositive := orig >= 0
-	// all bits set on uint64 is the only special case not detected by roundtrip (afaik).
-	if origPositive && (uint64(orig) == all64bitsOne) {
-		err = ErrOutOfRange
-		return
-	}
 	converted = NumOut(orig)
 	if origPositive != (converted >= 0) {
 		err = ErrOutOfRange
 		return
 	}
 	if NumIn(converted) != orig {
-		err = ErrOutOfRange
+		// checking for NaNs is completely optimized out for integer types.
+		// we declare NaN mantissa bits truncation during float64 -> float32 conversion as safe
+		bothNaN := (orig != orig) && (converted != converted)
+		if !bothNaN {
+			err = ErrOutOfRange
+		}
 	}
 	return
 }

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -3,6 +3,8 @@ package safecast_test
 import (
 	"fmt"
 	"math"
+	"reflect"
+	"strconv"
 	"testing"
 
 	"fortio.org/safecast"
@@ -19,7 +21,7 @@ const all64bitsOne = ^uint64(0)
 func FindNumIntBits[T safecast.Float](t *testing.T) int {
 	var v T
 	for i := 0; i < 64; i++ {
-		bits := (all64bitsOne >> i)
+		bits := all64bitsOne >> i
 		v = T(bits)
 		t.Logf("bits %02d: %b : %d -> %T %.0f %t", 64-i, bits, bits, v, v, uint64(v) == bits)
 		if v != v-1 {
@@ -254,4 +256,210 @@ func ExampleMustRound() {
 	out := safecast.MustRound[int8](-128.6)
 	fmt.Println("not reached", out) // not reached
 	// Output: panic: safecast: out of range for -128.6 (float64) to int8
+}
+
+// We need this function, because 'f' format does not work as expected.
+// Consider the following code:
+//
+//	src := 72057594037927936 // 2^56
+//	dst := safecast.MustConvert[float32](src)
+//	t.Logf("%d (0x%x) -> %s (%s)", src, src,
+//		strconv.FormatFloat(float64(dst), 'f', -1, 32),
+//		strconv.FormatFloat(float64(dst), 'x', -1, 32))
+//
+// It prints
+//
+//	72057594037927936 (0x100000000000000) -> 72057594000000000 (0x1p+56)
+//
+// So despite the actual number (float hex format is lossless)
+// being stored in float is 72057594037927936,
+// formatter is printed it as 72057594000000000.
+func strconvAppendGoodFloat(w []byte, v float64) ([]byte, bool) {
+	bits := math.Float64bits(v)
+	// Get the raw IEEE 754 bit representation of the float64
+	// Extract the sign bit
+	sign := (bits >> 63) & 1
+	// Extract the exponent bits
+	// Mask the exponent bits (bits 52-62) and shift them to the right
+	exponentBits := (bits >> 52) & 0x7FF // 0x7FF is 11 ones in binary (2^11 - 1)
+	// Extract the mantissa bits
+	// Mask the mantissa bits (bits 0-51)
+	mantissaBits := bits & 0xFFFFFFFFFFFFF // 52 ones in binary (2^52 - 1)
+
+	if exponentBits == 0 && mantissaBits == 0 { // +0 -0
+		return append(w, '0'), true
+	}
+	if exponentBits == 0 { // denormalized
+		return w, false
+	}
+	if exponentBits == 0x7FF { // +inf, -inf, all nans
+		return w, false
+	}
+
+	u := mantissaBits | (1 << 52) // put implicit 1.
+
+	e := int(exponentBits) - 0x3FF - 52
+
+	for e > 0 {
+		if u&(1<<63) != 0 {
+			return w, false // would overflow
+		}
+		u <<= 1
+		e--
+	}
+	for e < 0 {
+		if u&1 != 0 {
+			return w, false // would underflow
+		}
+		u >>= 1
+		e++
+	}
+	if sign != 0 {
+		w = append(w, '-')
+	}
+	return strconv.AppendUint(w, u, 10), true
+}
+
+func strconvAppend[Arg safecast.Number](w []byte, arg Arg) []byte {
+	switch v := any(arg).(type) {
+	case int:
+		return strconv.AppendInt(w, int64(v), 10)
+	case int8:
+		return strconv.AppendInt(w, int64(v), 10)
+	case int16:
+		return strconv.AppendInt(w, int64(v), 10)
+	case int32:
+		return strconv.AppendInt(w, int64(v), 10)
+	case int64:
+		return strconv.AppendInt(w, v, 10)
+	case uint:
+		return strconv.AppendUint(w, uint64(v), 10)
+	case uint8:
+		return strconv.AppendUint(w, uint64(v), 10)
+	case uint16:
+		return strconv.AppendUint(w, uint64(v), 10)
+	case uint32:
+		return strconv.AppendUint(w, uint64(v), 10)
+	case uint64:
+		return strconv.AppendUint(w, v, 10)
+	case uintptr:
+		return strconv.AppendUint(w, uint64(v), 10)
+	case float32:
+		wg, ok := strconvAppendGoodFloat(w, float64(v))
+		if ok {
+			return wg
+		}
+		return strconv.AppendFloat(w, float64(v), 'g', -1, 64)
+	case float64:
+		wg, ok := strconvAppendGoodFloat(w, v)
+		if ok {
+			return wg
+		}
+		return strconv.AppendFloat(w, v, 'g', -1, 64)
+	default:
+		panic("must be never")
+	}
+}
+
+func testCast[Result safecast.Number, Arg safecast.Number](t *testing.T, arg Arg) {
+	var scratch1 [64]byte
+	var scratch2 [64]byte
+	_, err := safecast.Convert[Result](arg)
+	builtinCast := Result(arg)
+	s1 := strconvAppend(scratch1[:0], arg)
+	s2 := strconvAppend(scratch2[:0], builtinCast)
+	good := string(s1) == string(s2)
+
+	if (err == nil) != good {
+		t.Errorf("%v %s -> %s %s\n", reflect.TypeOf(arg).String(), s1, reflect.TypeOf(builtinCast).String(), s2)
+	}
+}
+
+func testCasts[Arg safecast.Number](t *testing.T, arg Arg) {
+	testCast[int](t, arg)
+	testCast[int8](t, arg)
+	testCast[int16](t, arg)
+	testCast[int32](t, arg)
+	testCast[int64](t, arg)
+	testCast[uint](t, arg)
+	testCast[uint8](t, arg)
+	testCast[uint16](t, arg)
+	testCast[uint32](t, arg)
+	testCast[uint64](t, arg)
+	testCast[uintptr](t, arg)
+	testCast[float32](t, arg)
+	testCast[float64](t, arg)
+}
+
+func getPatterns(highBits uint64, shift byte) (uint64, uint64, uint64) {
+	mask := uint64((1<<64)-1) >> (64 - shift)
+	pattern1 := mask | (highBits << shift) // 00..00XFF..FF
+	pattern2 := highBits << shift          // 00..00X00..00
+	pattern3 := ^pattern1                  // FF..FFX00..00
+	return pattern1, pattern2, pattern3
+}
+
+func testCastsFromInteger[Arg safecast.Number](t *testing.T) {
+	for highBits := uint64(0); highBits < 16; highBits++ {
+		for sh := 0; sh < 60; sh++ { // +4 bits in highBits
+			p1, p2, p3 := getPatterns(highBits, byte(sh))
+			testCasts(t, Arg(p1))
+			testCasts(t, Arg(p2))
+			testCasts(t, Arg(p3))
+		}
+	}
+}
+
+func testCastsFromFloat[Arg safecast.Number](t *testing.T) {
+	for highBits := uint64(0); highBits < 16; highBits++ {
+		for sh := 0; sh < 8; sh++ { // +4 bits in highBits
+			p1, p2, p3 := getPatterns(highBits, byte(sh))
+			testCastsFromFloatExp[Arg](t, p1)
+			testCastsFromFloatExp[Arg](t, p2)
+			testCastsFromFloatExp[Arg](t, p3)
+		}
+	}
+}
+
+func testCastsFromFloatExp[Arg safecast.Number](t *testing.T, expPattern uint64) {
+	for sign := uint64(0); sign < 2; sign++ {
+		for highBits := uint64(0); highBits < 16; highBits++ {
+			for sh := 0; sh < 48; sh++ { // +4 bits in highBits
+				p1, p2, p3 := getPatterns(highBits, byte(sh))
+				testCasts(t, Arg(assembleFloat(sign, p1, expPattern)))
+				testCasts(t, Arg(assembleFloat(sign, p2, expPattern)))
+				testCasts(t, Arg(assembleFloat(sign, p3, expPattern)))
+			}
+		}
+	}
+}
+
+func assembleFloat(sign, exp, mantissa uint64) float64 {
+	bits := ((sign & 1) << 63) | ((exp & 0x7FF) << 52) | (mantissa & 0xFFFFFFFFFFFFF)
+	ret := math.Float64frombits(bits)
+	return ret
+}
+
+func TestPatterns(t *testing.T) {
+	// some cases we triggered failure on and made fixes for
+	testCast[byte](t, 9223372036854775807)
+	testCast[float32](t, math.NaN())
+	testCast[float64](t, float32(math.NaN()))
+	testCast[float32](t, math.NaN())
+	testCast[float64](t, float32(math.NaN()))
+	testCast[byte](t, math.NaN())
+
+	testCastsFromInteger[int](t)
+	testCastsFromInteger[int8](t)
+	testCastsFromInteger[int16](t)
+	testCastsFromInteger[int32](t)
+	testCastsFromInteger[int64](t)
+	testCastsFromInteger[uint](t)
+	testCastsFromInteger[uint8](t)
+	testCastsFromInteger[uint16](t)
+	testCastsFromInteger[uint32](t)
+	testCastsFromInteger[uint64](t)
+	testCastsFromInteger[uintptr](t)
+	testCastsFromFloat[float32](t)
+	testCastsFromFloat[float64](t)
 }

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -263,13 +263,13 @@ func ExampleMustRound() {
 //
 //	src := 72057594037927936 // 2^56
 //	dst := safecast.MustConvert[float32](src)
-//	t.Logf("%d (0x%x) -> %s (%s)", src, src,
+//	t.Logf("0x%x -> %s (%s)", src,
 //		strconv.FormatFloat(float64(dst), 'f', -1, 32),
 //		strconv.FormatFloat(float64(dst), 'x', -1, 32))
 //
 // It prints
 //
-//	72057594037927936 (0x100000000000000) -> 72057594000000000 (0x1p+56)
+//	0x100000000000000 -> 72057594000000000 (0x1p+56)
 //
 // So despite the actual number (float hex format is lossless)
 // being stored in float is 72057594037927936,


### PR DESCRIPTION
I could not find why you need a special case for all one 64-bit bit pattern.

Could you please provide a test case, which proofs that is is really needed? So if you remove special case like I did, some test fails.

I decided to play myself, removed special case and added what I think is exhaustive test around interesting bit patterns.

I wanted a property-based test, and created `strconvAppend` function, which prints values into string with maximum precision.

And after some experimenting, it seems we cannot and should not use round-trip check for floats.

You can uncomment lines with float32 and float64 in code I added, and see for yourself.

```
	// testCast[float32](t, arg)
	// testCast[float64](t, arg)
```

int 72057594037927936 -> float32 72057594037927940