### PR TITLE
Fix issue with max int32/int64 conversion to float 32, add a simpler safecast.Conv and safecast.MustConv that only deal with Integers (leaving Convert for backward compatibility)

### DIFF
--- a/.github/workflows/include.yml
+++ b/.github/workflows/include.yml
@@ -11,7 +11,7 @@ jobs:
     call-gochecks:
         uses: fortio/workflows/.github/workflows/gochecks.yml@main
     call-codecov:
-        uses: fortio/workflows/.github/workflows/codecov.yml@main
+        uses: fortio/workflows/.github/workflows/codecov.yml@arm_coverage
         secrets:
             CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     call-codeql:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/bf83c496d49b169cd744/maintainability)](https://codeclimate.com/github/fortio/safecast/maintainability)
 [![CI Checks](https://github.com/fortio/safecast/actions/workflows/include.yml/badge.svg)](https://github.com/fortio/safecast/actions/workflows/include.yml)
 
-Avoid accidental overflow of numbers during go type conversions (e.g instead of `shorter := bigger.(int8)` type conversions use `shorter := safecast.MustConvert[int8](bigger)`.
+Avoid accidental overflow of numbers during go type conversions (e.g instead of `shorter := bigger.(int8)` type conversions use `shorter := safecast.MustConv[int8](bigger)`.
 
 Safecast allows you to safely convert between numeric types in Go and return errors (or panic when using the `Must*` variants) when the cast would result in a loss of precision, range or sign.
 
@@ -16,3 +16,5 @@ This is usable from any go with generics (1.18 or later) though our CI uses the 
 `safecast` is about avoiding [gosec G115](https://github.com/securego/gosec#available-rules) and [CWE-190: Integer Overflow or Wraparound](https://cwe.mitre.org/data/definitions/190.html) class of overflow and loss of precision bugs, extended to float64/float32 issues.
 
 Credit for the idea (and a finding a bug in the first implementation) goes to [@ccoVeille](https://github.com/ccoVeille), Please see https://github.com/ccoVeille/go-safecast for an different style API and implementation to pick whichever fits your style best.
+
+Please note that conversions from integer to float are suffering from CPU architecture differences and issues at the "edge" (max int) which are handled by Convert but you should use the new int only Conv/MustConv if possible, to avoid them.

--- a/safecast.go
+++ b/safecast.go
@@ -38,13 +38,21 @@ const all63bits = uint64(math.MaxInt64)
 // Do not use for identity (same type in and out) but in particular this
 // will error for Convert[uint64](uint64(math.MaxUint64)) or
 // Convert[int64](int64(math.MaxInt64)) because it needs to
-// when converting to any float.
+// when converting to any float. Note that +Inf will convert correctly (as in error
+// only if going to an integer type) from a float64/float32 and not a ~float (it will
+// error from say ~float32 to float64 while it shouldn't).
 func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err error) {
 	origPositive := orig >= 0
 	// All bits set on uint64 is one of 3 special cases not detected by roundtrip (afaik).
 	if origPositive && (uint64(orig)&all63bits == all63bits) {
-		err = ErrOutOfRange
-		return
+		// If we started from float we don't have to special case these bits (handles +Inf case too)
+		switch any(orig).(type) {
+		case float32, float64:
+			break
+		default:
+			err = ErrOutOfRange
+			return
+		}
 	}
 	converted = NumOut(orig)
 	if origPositive != (converted >= 0) {

--- a/safecast.go
+++ b/safecast.go
@@ -19,7 +19,7 @@ type Integer interface {
 }
 
 type Float interface {
-	~float32 | ~float64
+	~float32 | ~float64 // Consider removing the ~ because of +Inf issue.
 }
 
 type Number interface {
@@ -43,7 +43,7 @@ const all63bits = uint64(math.MaxInt64)
 // error from say ~float32 to float64 while it shouldn't).
 func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err error) {
 	origPositive := orig >= 0
-	// All bits set on uint64 is one of 3 special cases not detected by roundtrip (afaik).
+	// All bits set on uint64 or positive int63 are two of 3 special cases not detected by roundtrip (afaik).
 	if origPositive && (uint64(orig)&all63bits == all63bits) {
 		// If we started from float we don't have to special case these bits (handles +Inf case too)
 		switch any(orig).(type) {
@@ -63,7 +63,7 @@ func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err err
 		err = ErrOutOfRange
 		return
 	}
-	// And this is the 2nd weird case, maxint32 conversion to float32.
+	// And this is the 3rd weird case, maxint32 conversion to float32.
 	if origPositive && (uint64(orig) == uint64(math.MaxInt32)) && unsafe.Sizeof(converted) == 4 {
 		err = ErrOutOfRange
 	}

--- a/safecast.go
+++ b/safecast.go
@@ -28,19 +28,21 @@ type Number interface {
 
 var ErrOutOfRange = errors.New("out of range")
 
-const all64bitsOne = ^uint64(0) // same as uint64(math.MaxUint64)
+const all63bits = uint64(math.MaxInt64)
 
 // Convert converts a number from one type to another,
 // returning an error if the conversion would result in a loss of precision,
 // range or sign (overflow). In other words if the converted number is not
 // equal to the original number.
+// Use [Conv] instead if both of your types are Integer.
 // Do not use for identity (same type in and out) but in particular this
-// will error for Convert[uint64](uint64(math.MaxUint64)) because it needs to
+// will error for Convert[uint64](uint64(math.MaxUint64)) or
+// Convert[int64](int64(math.MaxInt64)) because it needs to
 // when converting to any float.
 func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err error) {
 	origPositive := orig >= 0
-	// All bits set on uint64 is one of 2 special cases not detected by roundtrip (afaik).
-	if origPositive && (uint64(orig) == all64bitsOne) {
+	// All bits set on uint64 is one of 3 special cases not detected by roundtrip (afaik).
+	if origPositive && (uint64(orig)&all63bits == all63bits) {
 		err = ErrOutOfRange
 		return
 	}

--- a/safecast.go
+++ b/safecast.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"unsafe"
 )
 
 type Integer interface {
@@ -38,11 +39,33 @@ const all64bitsOne = ^uint64(0) // same as uint64(math.MaxUint64)
 // when converting to any float.
 func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err error) {
 	origPositive := orig >= 0
-	// all bits set on uint64 is the only special case not detected by roundtrip (afaik).
+	// All bits set on uint64 is one of 2 special cases not detected by roundtrip (afaik).
 	if origPositive && (uint64(orig) == all64bitsOne) {
 		err = ErrOutOfRange
 		return
 	}
+	converted = NumOut(orig)
+	if origPositive != (converted >= 0) {
+		err = ErrOutOfRange
+		return
+	}
+	if NumIn(converted) != orig {
+		err = ErrOutOfRange
+		return
+	}
+	// And this is the 2nd weird case, maxint32 conversion to float32.
+	if origPositive && (uint64(orig) == uint64(math.MaxInt32)) && unsafe.Sizeof(converted) == 4 {
+		err = ErrOutOfRange
+	}
+	return
+}
+
+// Conv is an integer only and simpler version of [Convert] without the
+// weird issue with round trip to floating point.
+// Unlike [Convert] it can be used for identity (same type in and out) even if that's
+// of dubious value.
+func Conv[NumOut Integer, NumIn Integer](orig NumIn) (converted NumOut, err error) {
+	origPositive := orig >= 0
 	converted = NumOut(orig)
 	if origPositive != (converted >= 0) {
 		err = ErrOutOfRange
@@ -56,7 +79,16 @@ func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err err
 
 // Same as Convert but panics if there is an error.
 func MustConvert[NumOut Number, NumIn Number](orig NumIn) NumOut {
-	converted, err := Convert[NumOut, NumIn](orig)
+	converted, err := Convert[NumOut](orig)
+	if err != nil {
+		doPanic(err, orig, converted)
+	}
+	return converted
+}
+
+// MustConv is as [Conv] but panics if there is an error.
+func MustConv[NumOut Integer, NumIn Integer](orig NumIn) NumOut {
+	converted, err := Conv[NumOut](orig)
 	if err != nil {
 		doPanic(err, orig, converted)
 	}

--- a/safecast.go
+++ b/safecast.go
@@ -42,7 +42,7 @@ const all63bits = uint64(math.MaxInt64)
 // only if going to an integer type) from a float64/float32 and not a ~float (it will
 // error from say ~float32 to float64 while it shouldn't).
 func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err error) {
-	origPositive := orig >= 0
+	origPositive := (orig >= 0)
 	// All bits set on uint64 or positive int63 are two of 3 special cases not detected by roundtrip (afaik).
 	if origPositive && (uint64(orig)&all63bits == all63bits) {
 		// If we started from float we don't have to special case these bits (handles +Inf case too)
@@ -75,7 +75,7 @@ func Convert[NumOut Number, NumIn Number](orig NumIn) (converted NumOut, err err
 // Unlike [Convert] it can be used for identity (same type in and out) even if that's
 // of dubious value.
 func Conv[NumOut Integer, NumIn Integer](orig NumIn) (converted NumOut, err error) {
-	origPositive := orig >= 0
+	origPositive := (orig >= 0)
 	converted = NumOut(orig)
 	if origPositive != (converted >= 0) {
 		err = ErrOutOfRange

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -3,6 +3,8 @@ package safecast_test
 import (
 	"fmt"
 	"math"
+	"reflect"
+	"strconv"
 	"testing"
 
 	"fortio.org/safecast"
@@ -94,8 +96,8 @@ func TestNonIntegerFloat(t *testing.T) {
 	}
 }
 
-// MaxUint64 special case and also MaxInt64+1.
-func TestMaxInt64(t *testing.T) {
+// MaxUint64 special case and also MinInt64+1.
+func TestMaxUint64(t *testing.T) {
 	f32, err := safecast.Convert[float32](all64bitsOne)
 	if err == nil {
 		t.Errorf("expected error, got %d -> %.0f", all64bitsOne, f32)
@@ -112,6 +114,19 @@ func TestMaxInt64(t *testing.T) {
 	t.Logf("minInt64p1 -> %.0f %d", f64, int2)
 	if err == nil {
 		t.Errorf("expected error, got %d -> %.0f", minInt64p1, f64)
+	}
+}
+
+// TestMaxInt64 special test.
+func TestMaxInt64(t *testing.T) {
+	mi64 := int64(math.MaxInt64)
+	f32, err := safecast.Convert[float32](mi64)
+	if err == nil {
+		t.Errorf("expected error, got %d -> %.0f", mi64, f32)
+	}
+	f64, err := safecast.Convert[float64](mi64)
+	if err == nil {
+		t.Errorf("expected error, got %d -> %.0f", mi64, f64)
 	}
 }
 
@@ -269,6 +284,8 @@ func TestConvInteger(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error")
 	}
+	var mi int32 = math.MaxInt32
+	_ = safecast.MustConv[int32](mi) // self on maxint32 shouldn't panic.
 }
 
 func TestNaNOk(t *testing.T) {
@@ -351,7 +368,7 @@ func TestPanicMustConv(t *testing.T) {
 func Example() {
 	var in int16 = 256
 	// will error out
-	out, err := safecast.Convert[uint8](in)
+	out, err := safecast.Conv[uint8](in)
 	fmt.Println(out, err)
 	// will be fine
 	out = safecast.MustRound[uint8](255.4)

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -3,8 +3,6 @@ package safecast_test
 import (
 	"fmt"
 	"math"
-	"reflect"
-	"strconv"
 	"testing"
 
 	"fortio.org/safecast"

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -138,6 +138,20 @@ func TestFloat32Int32Bounds(t *testing.T) {
 	}
 }
 
+func TestFloat32UInt32Bounds(t *testing.T) {
+	float32bits := FindNumIntBits[float32](t)
+	float32int32 := uint32(1<<(float32bits+1) - 1) // 25 bits is start of error range
+	for i := 0; i < 32-float32bits; i++ {
+		t.Logf("float32int %b %d", float32int32, float32int32)
+		f, err := safecast.Convert[float32](float32int32)
+		t.Logf("float32int -> %.0f", f)
+		if err == nil {
+			t.Errorf("expected error for %d (%x %b) -> %.0f", float32int32, float32int32, float32int32, f)
+		}
+		float32int32 = float32int32<<1 | 1
+	}
+}
+
 func TestConvert(t *testing.T) {
 	var inp uint32 = 42
 	out, err := safecast.Convert[int8](inp)

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -121,6 +121,15 @@ func TestMaxInt32(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error, got %d (%x) -> %.0f", inp, inp, f32)
 	}
+	// but should work to 64 bits types
+	_ = safecast.MustConvert[float64](inp)
+	_ = safecast.MustConvert[uint64](inp)
+	i64 := safecast.MustConvert[int64](inp)
+	// 64 bits variant of same maxint32 should also error out to 32 bits:
+	f32, err = safecast.Convert[float32](i64)
+	if err == nil {
+		t.Errorf("expected error, got %d (%x) -> %.0f", i64, i64, f32)
+	}
 }
 
 // Same as above but checks all the 25->31 bits.
@@ -135,6 +144,46 @@ func TestFloat32Int32Bounds(t *testing.T) {
 			t.Errorf("expected error for %d (%x %b) -> %.0f", float32int32, float32int32, float32int32, f)
 		}
 		float32int32 = float32int32<<1 | 1
+	}
+}
+
+func TestConvInteger(t *testing.T) {
+	var maxU64 uint64 = math.MaxUint64
+	_ = safecast.MustConv[uint64](maxU64) // shouldn't panic
+	var inp uint32 = 42
+	out, err := safecast.Conv[int8](inp)
+	t.Logf("Out is %T: %v", out, out)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if out != 42 {
+		t.Errorf("unexpected value: %v", out)
+	}
+	inp = 129
+	_, err = safecast.Conv[int8](inp)
+	t.Logf("Got err: %v", err)
+	if err == nil {
+		t.Errorf("expected error")
+	}
+	inp2 := int32(-1)
+	_, err = safecast.Conv[uint8](inp2)
+	t.Logf("Got err: %v", err)
+	if err == nil {
+		t.Errorf("expected error")
+	}
+	out, err = safecast.Conv[int8](inp2)
+	t.Logf("Out is %T: %v", out, out)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if out != -1 {
+		t.Errorf("unexpected value: %v", out)
+	}
+	inp2 = -129
+	_, err = safecast.Conv[uint8](inp2)
+	t.Logf("Got err: %v", err)
+	if err == nil {
+		t.Errorf("expected error")
 	}
 }
 
@@ -264,6 +313,21 @@ func TestPanicMustConvert(t *testing.T) {
 		}
 	}()
 	safecast.MustConvert[uint8](256)
+}
+
+func TestPanicMustConv(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("expected panic")
+		} else {
+			expected := "safecast: out of range for 256 (int) to uint8"
+			if r != expected {
+				t.Errorf("unexpected panic: %q wanted %q", r, expected)
+			}
+		}
+	}()
+	safecast.MustConv[uint8](256)
 }
 
 func Example() {

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -147,46 +147,6 @@ func TestFloat32Int32Bounds(t *testing.T) {
 	}
 }
 
-func TestConvInteger(t *testing.T) {
-	var maxU64 uint64 = math.MaxUint64
-	_ = safecast.MustConv[uint64](maxU64) // shouldn't panic
-	var inp uint32 = 42
-	out, err := safecast.Conv[int8](inp)
-	t.Logf("Out is %T: %v", out, out)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if out != 42 {
-		t.Errorf("unexpected value: %v", out)
-	}
-	inp = 129
-	_, err = safecast.Conv[int8](inp)
-	t.Logf("Got err: %v", err)
-	if err == nil {
-		t.Errorf("expected error")
-	}
-	inp2 := int32(-1)
-	_, err = safecast.Conv[uint8](inp2)
-	t.Logf("Got err: %v", err)
-	if err == nil {
-		t.Errorf("expected error")
-	}
-	out, err = safecast.Conv[int8](inp2)
-	t.Logf("Out is %T: %v", out, out)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if out != -1 {
-		t.Errorf("unexpected value: %v", out)
-	}
-	inp2 = -129
-	_, err = safecast.Conv[uint8](inp2)
-	t.Logf("Got err: %v", err)
-	if err == nil {
-		t.Errorf("expected error")
-	}
-}
-
 func TestFloat32UInt32Bounds(t *testing.T) {
 	float32bits := FindNumIntBits[float32](t)
 	float32int32 := uint32(1<<(float32bits+1) - 1) // 25 bits is start of error range
@@ -267,6 +227,47 @@ func TestConvert(t *testing.T) {
 	ub = safecast.MustConvert[uint8](int64(255)) // shouldn't panic
 	if ub != 255 {
 		t.Errorf("unexpected value: %v", ub)
+	}
+}
+
+// a bit of copy pasta from the previous test.
+func TestConvInteger(t *testing.T) {
+	var maxU64 uint64 = math.MaxUint64
+	_ = safecast.MustConv[uint64](maxU64) // shouldn't panic
+	var inp uint32 = 42
+	out, err := safecast.Conv[int8](inp)
+	t.Logf("Out is %T: %v", out, out)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if out != 42 {
+		t.Errorf("unexpected value: %v", out)
+	}
+	inp = 129
+	_, err = safecast.Conv[int8](inp)
+	t.Logf("Got err: %v", err)
+	if err == nil {
+		t.Errorf("expected error")
+	}
+	inp2 := int32(-1)
+	_, err = safecast.Conv[uint8](inp2)
+	t.Logf("Got err: %v", err)
+	if err == nil {
+		t.Errorf("expected error")
+	}
+	out, err = safecast.Conv[int8](inp2)
+	t.Logf("Out is %T: %v", out, out)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if out != -1 {
+		t.Errorf("unexpected value: %v", out)
+	}
+	inp2 = -129
+	_, err = safecast.Conv[uint8](inp2)
+	t.Logf("Got err: %v", err)
+	if err == nil {
+		t.Errorf("expected error")
 	}
 }
 

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -303,6 +303,42 @@ func TestNaNOk(t *testing.T) {
 	}
 }
 
+// Note this won't work is ~float because of the switch type.
+func TestPlusInfiniteOk(t *testing.T) {
+	inf64 := math.Inf(1)
+	inf32, err := safecast.Convert[float32](inf64)
+	if err != nil {
+		t.Errorf("unexpected 64->32 error %f -> %f: %v", inf64, inf32, err)
+	}
+	inf32 = float32(math.Inf(1))
+	outf64, err := safecast.Convert[float64](inf32)
+	if err != nil {
+		t.Errorf("unexpected 32->64 error %f -> %f: %v", inf32, outf64, err)
+	}
+}
+
+func TestPlusInfiniteToInt(t *testing.T) {
+	inf64 := math.Inf(1)
+	intInf, err := safecast.Convert[uint64](inf64)
+	if err == nil {
+		t.Errorf("expected inf to int error %f -> %d", inf64, intInf)
+	}
+}
+
+func TestMinusInfiniteOk(t *testing.T) {
+	inf64 := math.Inf(-1)
+	inf32, err := safecast.Convert[float32](inf64)
+	if err != nil {
+		t.Errorf("unexpected 64->32 error %f -> %f: %v", inf64, inf32, err)
+	}
+	t.Logf("inf32: %f", inf32)
+	inf32 = float32(math.Inf(-1))
+	outf64, err := safecast.Convert[float64](inf32)
+	if err != nil {
+		t.Errorf("unexpected 32->64 error %f -> %f: %v", inf32, outf64, err)
+	}
+}
+
 func TestPanicMustRound(t *testing.T) {
 	defer func() {
 		r := recover()

--- a/safecast_test.go
+++ b/safecast_test.go
@@ -26,7 +26,7 @@ func FindNumIntBits[T safecast.Float](t *testing.T) int {
 			return 64 - i
 		}
 	}
-	panic("bug... didn't fine num bits")
+	panic("bug... didn't find num bits")
 }
 
 // https://en.wikipedia.org/wiki/Double-precision_floating-point_format
@@ -112,6 +112,29 @@ func TestMaxInt64(t *testing.T) {
 	t.Logf("minInt64p1 -> %.0f %d", f64, int2)
 	if err == nil {
 		t.Errorf("expected error, got %d -> %.0f", minInt64p1, f64)
+	}
+}
+
+func TestMaxInt32(t *testing.T) {
+	var inp int32 = math.MaxInt32
+	f32, err := safecast.Convert[float32](inp)
+	if err == nil {
+		t.Errorf("expected error, got %d (%x) -> %.0f", inp, inp, f32)
+	}
+}
+
+// Same as above but checks all the 25->31 bits.
+func TestFloat32Int32Bounds(t *testing.T) {
+	float32bits := FindNumIntBits[float32](t)
+	float32int32 := int32(1<<(float32bits+1) - 1) // 25 bits is start of error range
+	for i := 0; i < 31-float32bits; i++ {
+		t.Logf("float32int %b %d", float32int32, float32int32)
+		f, err := safecast.Convert[float32](float32int32)
+		t.Logf("float32int -> %.0f", f)
+		if err == nil {
+			t.Errorf("expected error for %d (%x %b) -> %.0f", float32int32, float32int32, float32int32, f)
+		}
+		float32int32 = float32int32<<1 | 1
 	}
 }
 


### PR DESCRIPTION
- [x] Repro #16 
- [x] fixes #16 
- [x] Add int only version without the float induced warts : Conv and MustConv 
- [x] fixes #18

@hrissan ptal

Closes #16, #18